### PR TITLE
Fix MinGW native build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # OS detection. Not used in CI builds
 ifndef TARGET_OS
 ifeq ($(OS),Windows_NT)
-	TARGET_OS := win32
+	TARGET_OS := windows
 else
 	UNAME_S := $(shell uname -s)
 	ifeq ($(UNAME_S),Linux)
@@ -26,7 +26,7 @@ endif
 endif # TARGET_OS
 
 # OS-specific settings and build flags
-ifeq ($(TARGET_OS),win32)
+ifeq ($(TARGET_OS),windows)
 	ARCHIVE ?= zip
 	TARGET := mklittlefs.exe
 	TARGET_CFLAGS = -mno-ms-bitfields

--- a/build-cross.sh
+++ b/build-cross.sh
@@ -33,8 +33,8 @@ build ()
 )}
 
 tgt=osx pfx=x86_64-apple-darwin14 exe="" AHOST="x86_64-apple-darwin" build
-tgt=win32 pfx=x86_64-w64-mingw32 exe=".exe" AHOST="x86_64-mingw32" build
-tgt=win32 pfx=i686-w64-mingw32 exe=".exe" AHOST="i686-mingw32" build
+tgt=windows pfx=x86_64-w64-mingw32 exe=".exe" AHOST="x86_64-mingw32" build
+tgt=windows pfx=i686-w64-mingw32 exe=".exe" AHOST="i686-mingw32" build
 tgt=linux pfx=arm-linux-gnueabihf exe="" AHOST="arm-linux-gnueabihf" build
 tgt=linux pfx=aarch64-linux-gnu exe="" AHOST="aarch64-linux-gnu" build
 tgt=linux pfx=x86_64-linux-gnu exe="" AHOST="x86_64-pc-linux-gnu" build


### PR DESCRIPTION
`windows` and `win32` were used inconsistently in the makefile.  Adjust
to use only `win32` in build process.

Also, use `gcc` if no CC supplied by environment.

Fixes #9 