### PR TITLE
Set creation/modification time of volume on root

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -559,6 +559,12 @@ int actionPack() {
 
     littlefsFormat();
     int result = addFiles(s_dirName.c_str(), "/");
+
+    // Set creation/modification time of volume on root
+    time_t ct = time(NULL);
+    lfs_setattr(&s_fs, "/", 't', &ct, sizeof(ct));
+    lfs_setattr(&s_fs, "/", 'c', &ct, sizeof(ct));
+
     littlefsUnmount();
 
     fwrite(&s_flashmem[0], 4, s_flashmem.size()/4, fdres);
@@ -623,6 +629,12 @@ int actionList() {
     fclose(fdsrc);
     littlefsMount();
     listFiles("");
+
+    time_t ct;
+    if (lfs_getattr(&s_fs, "/", 't', &ct, sizeof(ct)) >= 0) { // and/or check 'c' as well?
+        std::cout << "Creation time:" << '\t' << asctime(gmtime(&ct));
+    }
+
     littlefsUnmount();
     return 0;
 }


### PR DESCRIPTION
Would you consider setting the creation and/or modification time attributes of the root "/" of the LittleFS to the timestamp of volume creation?

This PR adds:
- `actionPack`: setting the attributes 't' and 'c' to the time of build
- `actionList`: showing the creation time on list `-l`

Example output (diff):

```diff
 $ mklittlefs -p 256 -b 8192 -s 1024000 -l littlefs.bin
 5247    /client.js      Tue Dec 15 13:10:41 2020
 1747    /index.htm      Tue Dec 15 11:39:46 2020
 89476   /jquery-3.5.1.min.js    Mon May  4 23:02:39 2020
 71      /style.css      Fri Jul 17 13:57:50 2020
+Creation time:  Wed Feb 10 18:21:19 2021
```