### PR TITLE
Follow littlefs file name spec, update for compiling for c++ 20, update gitignore for binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ build
 .project
 .cproject
 .settings
+
+# binaries
+mklittlefs

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ override CPPFLAGS := \
 	-D BUILD_CONFIG=\"$(BUILD_CONFIG_STR)\" \
 	-D BUILD_CONFIG_NAME=\"$(BUILD_CONFIG_NAME)\" \
 	-D __NO_INLINE__ \
-	-D LFS_NAME_MAX=32 \
+	-D LFS_NAME_MAX=255 \
 	$(CPPFLAGS)
 
 override CFLAGS := -std=gnu99 -Os -Wall -Wextra -Werror $(TARGET_CFLAGS) $(CFLAGS)

--- a/tclap/MultiArg.h
+++ b/tclap/MultiArg.h
@@ -225,7 +225,7 @@ private:
 	/**
 	 * Prevent accidental copying
 	 */
-	MultiArg<T>(const MultiArg<T>& rhs);
+	MultiArg(const MultiArg& rhs);
 	MultiArg<T>& operator=(const MultiArg<T>& rhs);
 
 };

--- a/tclap/ValueArg.h
+++ b/tclap/ValueArg.h
@@ -240,7 +240,7 @@ private:
        /**
         * Prevent accidental copying
         */
-       ValueArg<T>(const ValueArg<T>& rhs);
+       ValueArg(const ValueArg& rhs);
        ValueArg<T>& operator=(const ValueArg<T>& rhs);
 };
 


### PR DESCRIPTION
As described here:
https://github.com/arduino-libraries/Arduino_UnifiedStorage/issues/42
This tool, and littlefs implementation here: https://github.com/esp8266/Arduino are the only ones using LFS_NAME_MAX=32 instead of 255