### PR TITLE
Add Mac brew building to release

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-linux:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
Thanks @Jason2866!  Fixes #62

Make a ZIP not TAR on Max for Brew support